### PR TITLE
Match bool in create_sobject success

### DIFF
--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -177,7 +177,7 @@ defmodule ExForce do
   @spec create_sobject(sobject_name, map, config_or_func) :: :ok | {:error, any}
   def create_sobject(name, attrs, config \\ default_config()) do
     case request_post("/sobjects/#{name}/", Poison.encode!(attrs), config) do
-      {201, %{"id" => id, "success" => "true"}} ->
+      {201, %{"id" => id, "success" => true}} ->
         {:ok, id}
 
       {_, raw} ->

--- a/test/ex_force_test.exs
+++ b/test/ex_force_test.exs
@@ -296,7 +296,7 @@ defmodule ExForceTest do
       {
         "id": "001D000000IqhSLIAZ",
         "errors": [],
-        "success": "true",
+        "success": true,
         "warnings": []
       }
       """


### PR DESCRIPTION
Salesforce sends a JSON boolean as the value for the "success" key, which Poison decodes as an Elixir boolean.

Fixes #14 