### PR TITLE
Fix spec for ExForce.create_sobject/3 to include {:ok, id} tuple

### DIFF
--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -215,7 +215,7 @@ defmodule ExForce do
 
   See [SObject Rows](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_basic_info.htm)
   """
-  @spec create_sobject(client, sobject_name, map) :: :ok | {:error, any}
+  @spec create_sobject(client, sobject_name, map) :: {:ok, sobject_id} | {:error, any}
   def create_sobject(client, name, attrs) do
     case request(client, method: :post, url: "sobjects/#{name}/", body: attrs) do
       {:ok, %Tesla.Env{status: 201, body: %{"id" => id, "success" => true}}} -> {:ok, id}


### PR DESCRIPTION
Hey 👋!

It seems like the spec for the `ExForce.create_sobject/3` method didn't match the actual return which causes the documentation to suggest the id isn't available (and also ends up suggesting a "unmatchable" return value `:ok`).

This should fix that. Thanks for putting in the time to build ex_force, it saved me so much time!