### PR TITLE
Add adapter to opts, allowing to add custom configuration to the adapter

### DIFF
--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -90,6 +90,7 @@ defmodule ExForce do
 
   - `:headers`: set additional headers; default: `[{"user-agent", "#{@default_user_agent}"}]`
   - `:api_version`: use the given api_version; default: `"#{@default_api_version}"`
+  - `:adapter`: use the given adapter with custom opts; default: `nil`, which causes Tesla to use the default adapter or the one set in config.
   """
   def build_client(instance_url_or_map, opts \\ [headers: [{"user-agent", @default_user_agent}]])
 
@@ -108,7 +109,7 @@ defmodule ExForce do
       {Tesla.Middleware.Compression, format: "gzip"},
       {Tesla.Middleware.JSON, engine: Jason},
       {Tesla.Middleware.Headers, Keyword.get(opts, :headers, [])}
-    ])
+    ], Keyword.get(opts, :adapter))
   end
 
   @doc """


### PR DESCRIPTION
We have 3 options to set custom configuration for the adapters in Tesla: https://github.com/teamon/tesla#adapter-options

Currently, this lib only allows the adapter to be set through `config.exs`, but through this way it's not possible to set custom opts, so passing the adapter with options when building the client seems to be the easiest way to do this.

My use case is to increase `hackney` timeout, like this:

```elixir
ExForce.build_client(oauth_response, api_version: version, adapter: {Tesla.Adapter.Hackney, [recv_timeout: timeout()]})
```