### PR TITLE
Allow Tesla middleware to be configured

### DIFF
--- a/test/ex_force/client/tesla_test.exs
+++ b/test/ex_force/client/tesla_test.exs
@@ -1,0 +1,53 @@
+defmodule ExForce.Client.TeslaTest do
+  use ExUnit.Case, async: false
+  alias ExForce.{Client, Request}
+  alias Plug.Conn
+
+  defmodule TestMiddleware do
+    @behaviour Tesla.Middleware
+
+    @impl Tesla.Middleware
+    def call(env, next, test_pid: test_pid, id: id) when is_pid(test_pid) do
+      send(test_pid, {:before, id})
+      result = Tesla.run(env, next)
+      send(test_pid, {:after, id})
+
+      result
+    end
+  end
+
+  setup do
+    %{bypass: Bypass.open()}
+  end
+
+  test "it will use the custom middleware provided to it", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "GET", "/foo", fn conn ->
+      conn
+      |> Conn.put_resp_content_type("application/json")
+      |> Conn.resp(200, ~w({"hello": "world"}))
+    end)
+
+    client =
+      ExForce.Client.Tesla.build_client(%{instance_url: bypass_url(bypass), access_token: "foo"},
+        middleware: [
+          {TestMiddleware, test_pid: self(), id: 1},
+          {TestMiddleware, test_pid: self(), id: 2},
+          {TestMiddleware, test_pid: self(), id: 3}
+        ]
+      )
+
+    {:ok, _response} = Client.request(client, %Request{url: "/foo", method: :get})
+
+    assert {:messages,
+            [
+              before: 1,
+              before: 2,
+              before: 3,
+              after: 3,
+              after: 2,
+              after: 1
+            ]} = Process.info(self(), :messages)
+  end
+
+  defp bypass_url(bypass), do: "http://127.0.0.1:#{bypass.port}"
+end


### PR DESCRIPTION
To provide support for custom middleware, allow the
`ExForce.Client.Tesla.build_client/2` method to take an additional param
in it's opts argument defining middleware to run.

The choice was made to allow users to provide their own instrumentation

The middleware runs _before_ the compression/json encoding and _after_ the
API version headers