### PR TITLE
Fix default headers

### DIFF
--- a/lib/ex_force/client/tesla/tesla.ex
+++ b/lib/ex_force/client/tesla/tesla.ex
@@ -28,7 +28,7 @@ defmodule ExForce.Client.Tesla do
 
   - `:headers`: set additional headers; default: `[{"user-agent", "#{@default_user_agent}"}]`
   - `:api_version`: use the given api_version; default: `"#{@default_api_version}"`
-  - `:adapter`: use the given adapter with custom opts; default: `nil`, which causes Tesla to use the default adapter or the one set in config.
+  - `:adapter`: use the given adapter with custom opts; default: `nil`, which makes `Tesla` to use the default adapter or the one set in config.
   """
   @impl ExForce.Client
   def build_client(context, opts \\ [])
@@ -61,6 +61,7 @@ defmodule ExForce.Client.Tesla do
   ### Options
 
   - `:headers`: set additional headers; default: `[{"user-agent", "#{@default_user_agent}"}]`
+  - `:adapter`: use the given adapter with custom opts; default: `nil`, which makes `Tesla` to use the default adapter or the one set in config.
   """
   @impl ExForce.Client
   def build_oauth_client(instance_url, opts \\ []) do

--- a/test/ex_force_test.exs
+++ b/test/ex_force_test.exs
@@ -100,6 +100,7 @@ defmodule ExForceTest do
   test "build_client/2 - url - api_version - opts", %{bypass: bypass} do
     Bypass.expect_once(bypass, "GET", "/services/data/v12345.0/foo", fn conn ->
       conn
+      |> assert_req_header("user-agent", ["ex_force"])
       |> Conn.put_resp_content_type("application/json")
       |> Conn.resp(200, ~w({"hello": "world"}))
     end)


### PR DESCRIPTION
The existing code uses the default argument for default value for `headers` option. This is not working when any option is given (e.g. `api_version` option is given for example) - then the default value won't be used.

This is a changing behavior, but it shouldn't break anything. I'm not sure it should be minor or patch bump.