### PR TITLE
Updated deps, http client, from chulkilee, then re-added safer query-stream handling

### DIFF
--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -354,8 +354,13 @@ defmodule ExForce do
           soql
         ) :: Enumerable.t()
   defp start_query_stream(client, func, soql) do
-    {:ok, qr} = func.(client, soql)
-    stream_query_result(client, qr)
+    case func.(client, soql) do
+      {:ok, qr} ->
+        stream_query_result(client, qr)
+
+      {:error, _} = other ->
+        other
+    end
   end
 
   @doc """
@@ -373,8 +378,13 @@ defmodule ExForce do
          client,
          %QueryResult{records: [], done: false, next_records_url: next_records_url}
        }) do
-    {:ok, %QueryResult{records: [h | tail]} = qr} = query_retrieve(client, next_records_url)
-    {h, {client, %QueryResult{qr | records: tail}}}
+    case query_retrieve(client, next_records_url) do
+      {:ok, %QueryResult{records: [h | tail]} = qr} ->
+        {h, {client, %QueryResult{qr | records: tail}}}
+
+      {:error, _} = other ->
+        other
+    end
   end
 
   defp stream_unfold({_client, %QueryResult{records: [], done: true}}), do: nil

--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -40,6 +40,8 @@ defmodule ExForce do
     |> Stream.take(50)
     |> Enum.to_list()
   ```
+
+  Note that streams emit `ExForce.SObject` or an error tuple.
   """
 
   alias ExForce.{
@@ -350,17 +352,16 @@ defmodule ExForce do
 
   @spec start_query_stream(
           client,
-          (client, soql -> {:ok, QueryResult.t()} | any),
+          (client, soql -> {:ok, QueryResult.t()} | {:error, any}),
           soql
         ) :: Enumerable.t()
-  defp start_query_stream(client, func, soql) do
-    case func.(client, soql) do
-      {:ok, qr} ->
-        stream_query_result(client, qr)
 
-      {:error, _} = other ->
-        other
-    end
+  defp start_query_stream(client, func, soql) do
+    Stream.resource(
+      fn -> {client, func.(client, soql)} end,
+      &stream_next/1,
+      fn _acc -> nil end
+    )
   end
 
   @doc """
@@ -368,26 +369,27 @@ defmodule ExForce do
   """
   @spec stream_query_result(client, QueryResult.t()) :: Enumerable.t()
   def stream_query_result(client, %QueryResult{} = qr) do
-    Stream.unfold({client, qr}, &stream_unfold/1)
+    Stream.resource(
+      fn -> {client, {:ok, qr}} end,
+      &stream_next/1,
+      fn _acc -> nil end
+    )
   end
 
-  defp stream_unfold({client, %QueryResult{records: [h | tail]} = qr}),
-    do: {h, {client, %QueryResult{qr | records: tail}}}
+  defp stream_next({client, :halt}), do: {:halt, client}
 
-  defp stream_unfold({
-         client,
-         %QueryResult{records: [], done: false, next_records_url: next_records_url}
-       }) do
-    case query_retrieve(client, next_records_url) do
-      {:ok, %QueryResult{records: [h | tail]} = qr} ->
-        {h, {client, %QueryResult{qr | records: tail}}}
+  defp stream_next({client, {:error, _} = error_tuple}), do: {[error_tuple], {client, :halt}}
 
-      {:error, _} = other ->
-        other
-    end
-  end
+  defp stream_next({client, {:ok, %QueryResult{records: records, done: true}}}),
+    do: {records, {client, :halt}}
 
-  defp stream_unfold({_client, %QueryResult{records: [], done: true}}), do: nil
+  defp stream_next(
+         {client, {:ok, %QueryResult{records: records, done: false, next_records_url: url}}}
+       ),
+       do: {records, {client, {:retrieve, url}}}
+
+  defp stream_next({client, {:retrieve, next_records_url}}),
+    do: {[], {client, query_retrieve(client, next_records_url)}}
 
   defp full_path?(path), do: String.starts_with?(path, "/services/data/v")
 end


### PR DESCRIPTION
#50 was closed without being merged into `main` branch, presumably because of recent deps upgrades and changing the way `tesla` handles HTTP requests.

Those upstream changes have been rebased into the improved stream handling and tests are all passing now.

Now the stream creation always succeeds, but if a query fails, it will happen at the point of getting the next item.