### PR TITLE
Add default config in `config.exs` + ability to configure Tesla middleware

### DIFF
--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -14,17 +14,19 @@ defmodule ExForce do
   end
   ```
 
-  Configure default settings in config/config.exs (optional).
+  Configure default settings for the Tesla client (currently the only
+  client supported) in config/config.exs (optional).
 
   ```elixir
   # config/config.exs
 
-  config :ex_force, :api_version, "43.0"
-  config :ex_force, :adapter, {Tesla.Adapter.Hackney, [recv_timeout: 1_000]}
-  config :ex_force, :middleware, [
-    Tesla.Middleware.Telemetry,
-    {Tesla.Middleware.Timeout, timeout: :timer.seconds(1)}
-  ]
+  config :ex_force, ExForce.Client.Tesla,
+    api_version: "43.0",
+    adapter: {Tesla.Adapter.Hackney, [recv_timeout: 1_000]},
+    append_middleware: [
+      Tesla.Middleware.Telemetry,
+      {Tesla.Middleware.Timeout, timeout: :timer.seconds(1)}
+    ]
   ```
 
   Check out [Choosing a Tesla Adapter](https://github.com/chulkilee/ex_force/wiki/Choosing-a-Tesla-Adapter).

--- a/lib/ex_force.ex
+++ b/lib/ex_force.ex
@@ -14,6 +14,19 @@ defmodule ExForce do
   end
   ```
 
+  Configure default settings in config/config.exs (optional).
+
+  ```elixir
+  # config/config.exs
+
+  config :ex_force, :api_version, "43.0"
+  config :ex_force, :adapter, {Tesla.Adapter.Hackney, [recv_timeout: 1_000]}
+  config :ex_force, :middleware, [
+    Tesla.Middleware.Telemetry,
+    {Tesla.Middleware.Timeout, timeout: :timer.seconds(1)}
+  ]
+  ```
+
   Check out [Choosing a Tesla Adapter](https://github.com/chulkilee/ex_force/wiki/Choosing-a-Tesla-Adapter).
 
   ## Usage

--- a/lib/ex_force/client/tesla/tesla.ex
+++ b/lib/ex_force/client/tesla/tesla.ex
@@ -41,7 +41,6 @@ defmodule ExForce.Client.Tesla do
   end
 
   def build_client(instance_url, opts) when is_binary(instance_url) do
-    append_middleware = get_from_opts_or_config(opts, :append_middleware, [])
     adapter = get_from_opts_or_config(opts, :adapter)
     headers = get_headers(opts)
 
@@ -52,7 +51,7 @@ defmodule ExForce.Client.Tesla do
         {Tesla.Middleware.Compression, format: "gzip"},
         {Tesla.Middleware.JSON, engine: Jason},
         {Tesla.Middleware.Headers, headers}
-      ] ++ append_middleware
+      ] ++ get_from_opts_or_config(opts, :append_middleware, [])
 
     Tesla.client(middleware, adapter)
   end
@@ -70,7 +69,6 @@ defmodule ExForce.Client.Tesla do
   """
   @impl ExForce.Client
   def build_oauth_client(instance_url, opts \\ []) do
-    append_middleware = get_from_opts_or_config(opts, :append_middleware, [])
     adapter = get_from_opts_or_config(opts, :adapter)
 
     middleware =
@@ -80,7 +78,7 @@ defmodule ExForce.Client.Tesla do
         {Tesla.Middleware.Compression, format: "gzip"},
         Tesla.Middleware.FormUrlencoded,
         {Tesla.Middleware.Headers, get_headers(opts)}
-      ] ++ append_middleware
+      ] ++ get_from_opts_or_config(opts, :append_middleware, [])
 
     Tesla.client(middleware, adapter)
   end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,63 @@
+defmodule ExForce.ConfigTest do
+  # Must be set to async: false since this is manipulating global application config
+  use ExUnit.Case, async: false
+
+  alias ExForce.{
+    Client,
+    Request
+  }
+
+  alias Plug.Conn
+
+  test "build_client/2 - custom config" do
+    bypass = Bypass.open()
+    bypass_url = "http://127.0.0.1:#{bypass.port}"
+
+    api_version = "456.0"
+
+    custom_middleware = [
+      Tesla.Middleware.Telemetry,
+      {Tesla.Middleware.Timeout, timeout: :timer.seconds(1)}
+    ]
+
+    custom_middleware_representation = [
+      {Tesla.Middleware.Telemetry, :call, [[]]},
+      {Tesla.Middleware.Timeout, :call, [[timeout: 1000]]}
+    ]
+
+    custom_opts = [
+      api_version: api_version,
+      middleware: custom_middleware
+    ]
+
+    Application.put_all_env(ex_force: custom_opts)
+
+    on_exit(fn ->
+      Enum.each(custom_opts, fn {key, _} -> Application.delete_env(:ex_force, key) end)
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/foo", fn conn ->
+      conn
+      |> Conn.put_resp_content_type("application/json")
+      |> Conn.resp(200, ~w({"hello": "world"}))
+    end)
+
+    client = ExForce.build_client(bypass_url)
+
+    assert %Tesla.Client{
+             adapter: nil,
+             fun: nil,
+             post: [],
+             pre:
+               [
+                 {ExForce.Client.Tesla.Middleware, :call, [{^bypass_url, ^api_version}]},
+                 {Tesla.Middleware.Compression, :call, [[format: "gzip"]]},
+                 {Tesla.Middleware.JSON, :call, [[engine: Jason]]},
+                 {Tesla.Middleware.Headers, :call, [[{"user-agent", "ex_force"}]]}
+               ] ++ ^custom_middleware_representation
+           } = client
+
+    assert {:ok, %{status: 200, body: %{"hello" => "world"}}} =
+             Client.request(client, %Request{url: "/foo", method: :get})
+  end
+end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -25,16 +25,12 @@ defmodule ExForce.ConfigTest do
       {Tesla.Middleware.Timeout, :call, [[timeout: 1000]]}
     ]
 
-    custom_opts = [
+    Application.put_env(:ex_force, ExForce.Client.Tesla,
       api_version: api_version,
-      middleware: custom_middleware
-    ]
+      append_middleware: custom_middleware
+    )
 
-    Application.put_all_env(ex_force: custom_opts)
-
-    on_exit(fn ->
-      Enum.each(custom_opts, fn {key, _} -> Application.delete_env(:ex_force, key) end)
-    end)
+    on_exit(fn -> Application.delete_env(:ex_force, ExForce.Client.Tesla) end)
 
     Bypass.expect_once(bypass, "GET", "/foo", fn conn ->
       conn

--- a/test/ex_force/oauth_test.exs
+++ b/test/ex_force/oauth_test.exs
@@ -335,10 +335,10 @@ defmodule ExForce.OAuthTest do
              fun: nil,
              post: [],
              pre: [
+               {Tesla.Middleware.DecodeJson, :call, [[engine: Jason]]},
                {Tesla.Middleware.BaseUrl, :call, ["http://257.0.0.0:0"]},
                {Tesla.Middleware.Compression, :call, [[format: "gzip"]]},
                {Tesla.Middleware.FormUrlencoded, :call, [[]]},
-               {Tesla.Middleware.DecodeJson, :call, [[engine: Jason]]},
                {Tesla.Middleware.Headers, :call, [[{"user-agent", "agent"}]]}
              ]
            }

--- a/test/ex_force_test.exs
+++ b/test/ex_force_test.exs
@@ -48,8 +48,6 @@ defmodule ExForceTest do
 
   defp map_sobject_id(enum), do: Enum.map(enum, fn %SObject{id: id} -> id end)
 
-  defp get(client, url), do: Client.request(client, %Request{url: url, method: :get})
-
   test "build_client/2 - map", %{bypass: bypass} do
     Bypass.expect_once(bypass, "GET", "/", fn conn ->
       conn
@@ -1203,4 +1201,6 @@ defmodule ExForceTest do
              "account6"
            ]
   end
+
+  defp get(client, url), do: Client.request(client, %Request{url: url, method: :get})
 end

--- a/test/ex_force_test.exs
+++ b/test/ex_force_test.exs
@@ -48,6 +48,8 @@ defmodule ExForceTest do
 
   defp map_sobject_id(enum), do: Enum.map(enum, fn %SObject{id: id} -> id end)
 
+  defp get(client, url), do: Client.request(client, %Request{url: url, method: :get})
+
   test "build_client/2 - map", %{bypass: bypass} do
     Bypass.expect_once(bypass, "GET", "/", fn conn ->
       conn
@@ -1201,6 +1203,4 @@ defmodule ExForceTest do
              "account6"
            ]
   end
-
-  defp get(client, url), do: Client.request(client, %Request{url: url, method: :get})
 end


### PR DESCRIPTION
Inspired by #42

---

Adding the ability to configure default options in `config.exs`:

>   Configure default settings in config/config.exs (optional).
>    ```elixir
>    # config/config.exs
>    config :ex_force, :api_version, "43.0"
>    config :ex_force, :adapter, {Tesla.Adapter.Hackney, [recv_timeout: 1_000]}
>    ```

As well as the ability to pass in custom Tesla Middleware:

>    ```elixir
>    # config/config.exs
>    config :ex_force, :middleware, [
>       Tesla.Middleware.Telemetry,
>       {Tesla.Middleware.Timeout, timeout: :timer.seconds(1)}
>     ]
>    ```